### PR TITLE
chore: Bump version to v0.1.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.1.0] - 2025-05-10
+## [0.1.1] - 2025-05-10
 
 ### Added
 - **Enhanced `kickoff` Command (Dual Mode Functionality):**
@@ -173,7 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Link Definitions
 -->
 [Unreleased]: https://github.com/contextvibes/cli/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/contextvibes/cli/compare/v0.0.5...v0.1.0
+[0.1.1]: https://github.com/contextvibes/cli/compare/v0.0.5...v0.1.1
 [0.0.5]: https://github.com/contextvibes/cli/compare/v0.0.4...v0.0.5
 [0.0.4]: https://github.com/contextvibes/cli/compare/v0.0.3...v0.0.4
 [0.0.3]: https://github.com/contextvibes/cli/compare/v0.0.2...v0.0.3

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,7 +208,7 @@ var (
 func init() {
 	// Set the application version. This can be overridden by ldflags during build.
 	if AppVersion == "" {
-		AppVersion = "v0.1.0" // Default version if not set by build flags
+		AppVersion = "v0.1.1" // Default version if not set by build flags
 	}
 
 	// Define persistent flags available to all commands.


### PR DESCRIPTION
Prepares for v0.1.1 release which includes the enhanced kickoff feature.