### PR TITLE
feat(project): Implement interactive issue management workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ thea/
 context_*.md
 .env
 !contextvibes.nix
+
+# Build artifacts
+/bin/
+Taskfile.yml

--- a/cmd/improve.go
+++ b/cmd/improve.go
@@ -1,0 +1,136 @@
+// cmd/improve.go
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/huh"
+	"github.com/contextvibes/cli/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var (
+	issueType  string
+	issueTitle string
+	issueBody  string
+)
+
+var improveCmd = &cobra.Command{
+	Use:     "improve",
+	Aliases: []string{"issue", "suggest"},
+	Short:   "Create a new feature, bug, or chore suggestion as a GitHub Issue.",
+	Long:    `Creates a new GitHub Issue, either interactively or non-interactively via flags.\nThis command uses the 'gh' CLI in the background to create the issue with the provided details and appropriate labels.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		presenter := ui.NewPresenter(cmd.OutOrStdout(), cmd.ErrOrStderr())
+		ctx := cmd.Context()
+
+		if !ExecClient.CommandExists("gh") {
+			presenter.Error("GitHub CLI ('gh') not found. This command is required to create issues.")
+			presenter.Advice("Please install it from https://cli.github.com/ and authenticate with 'gh auth login'.")
+			return errors.New("gh cli not found")
+		}
+
+		// If title is provided via flag, run non-interactively.
+		if issueTitle != "" {
+			presenter.Info("Running in non-interactive mode.")
+			if issueType == "" {
+				issueType = "feature" // Default to feature
+				presenter.Info("No --type specified, defaulting to 'feature'.")
+			}
+		} else {
+			// Interactive flow using huh
+			form := huh.NewForm(
+				huh.NewGroup(
+					huh.NewSelect[string]().
+						Title("What kind of improvement is this?").
+						Options(
+							huh.NewOption("Feature Request", "feature"),
+							huh.NewOption("Bug Report", "bug"),
+							huh.NewOption("Chore / Refactor", "chore"),
+							huh.NewOption("Documentation", "documentation"),
+							huh.NewOption("Epic (Large Feature)", "epic"),
+						).
+						Value(&issueType),
+
+					huh.NewInput().
+						Title("What is the title for this issue?").
+						Value(&issueTitle).
+						Validate(func(s string) error {
+							if len(s) == 0 {
+								return fmt.Errorf("title cannot be empty")
+							}
+							return nil
+						}),
+
+					huh.NewText().
+						Title("Please describe the improvement.").
+						Value(&issueBody),
+				),
+			)
+
+			if err := form.Run(); err != nil {
+				presenter.Error("Improvement submission aborted: %v", err)
+				return err
+			}
+		}
+
+		// Get labels based on type
+		labels := []string{issueType}
+		if issueType == "feature" || issueType == "epic" {
+			labels = append(labels, "enhancement")
+		}
+
+		// Confirmation
+		var confirmed bool = false
+		if assumeYes {
+			confirmed = true
+		} else {
+			presenter.Newline()
+			presenter.Header("--- Issue Preview ---")
+			presenter.Detail("Title: %s", issueTitle)
+			presenter.Detail("Labels: %s", strings.Join(labels, ", "))
+			presenter.Step("Body:")
+			fmt.Fprintln(presenter.Out(), issueBody)
+			presenter.Newline()
+
+			var err error
+			confirmed, err = presenter.PromptForConfirmation("Create this issue on GitHub?")
+			if err != nil {
+				return err
+			}
+		}
+
+		if !confirmed {
+			presenter.Info("Issue creation aborted by user.")
+			return nil
+		}
+
+		// Execution
+		presenter.Step("Creating issue via 'gh' CLI...")
+		ghArgs := []string{
+			"issue", "create",
+			"--title", issueTitle,
+			"--body", issueBody,
+		}
+		for _, label := range labels {
+			ghArgs = append(ghArgs, "--label", label)
+		}
+
+		if err := ExecClient.Execute(ctx, ".", "gh", ghArgs...); err != nil {
+			presenter.Error("Failed to create GitHub issue: %v", err)
+			return err
+		}
+
+		presenter.Success("Successfully created issue.")
+		return nil
+	},
+}
+
+func init() {
+	projectCmd.AddCommand(improveCmd)
+	improveCmd.Flags().StringVarP(&issueType, "type", "t", "", "Type of the issue (feature, bug, chore, documentation, epic)")
+	improveCmd.Flags().StringVarP(&issueTitle, "title", "T", "", "Title of the issue")
+	improveCmd.Flags().StringVarP(&issueBody, "body", "b", "", "Body of the issue")
+}

--- a/cmd/project.go
+++ b/cmd/project.go
@@ -2,165 +2,16 @@
 package cmd
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-
-	"github.com/contextvibes/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-var outputFile string // Flag variable
-
-// --- Data Structures for GitHub JSON Output ---
-type Issue struct {
-	Number   int       `json:"number"`
-	Title    string    `json:"title"`
-	Author   Author    `json:"author"`
-	Body     string    `json:"body"`
-	Comments []Comment `json:"comments"`
-}
-
-type Author struct {
-	Login string `json:"login"`
-}
-
-type Comment struct {
-	Author Author `json:"author"`
-	Body   string `json:"body"`
-}
-
-// WriteTo conforms to the io.WriterTo interface, which is a Go standard.
-func (i *Issue) WriteTo(w io.Writer) (n int64, err error) {
-	// Use a temporary presenter to format output to the provided writer.
-	presenter := ui.NewPresenter(w, io.Discard)
-	var totalBytes int
-
-	// Helper to write and track byte count
-	write := func(format string, a ...any) {
-		if err != nil {
-			return
-		}
-		var written int
-		written, err = fmt.Fprintf(w, format, a...)
-		totalBytes += written
-	}
-
-	presenter.Header(fmt.Sprintf("#%d %s", i.Number, i.Title))
-	presenter.Detail("Author: %s", i.Author.Login)
-	presenter.Newline()
-	presenter.Step("Body:")
-	write("%s\n\n", i.Body)
-
-	if len(i.Comments) > 0 {
-		presenter.Step("Comments (%d):", len(i.Comments))
-		for _, comment := range i.Comments {
-			presenter.Separator()
-			presenter.Detail("Comment by %s:", comment.Author.Login)
-			write("%s\n", comment.Body)
-		}
-	}
-	presenter.Separator()
-
-	return int64(totalBytes), err
-}
-
-// --- Cobra Command Definitions ---
-
+// projectCmd represents the base command for the 'project' domain.
 var projectCmd = &cobra.Command{
 	Use:   "project",
-	Short: "Manages interactions with the Git hosting provider (e.g., GitHub).",
-	Long:  `Provides commands to interact with project management features of the Git hosting provider, such as issues and pull requests.`,
-}
-
-var listIssuesCmd = &cobra.Command{
-	Use:   "list-issues",
-	Short: "Fetches and displays all open issues for the current repository.",
-	Long:  `Fetches and displays all open issues, including their full body and all comments, from the current GitHub repository using the 'gh' CLI.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Presenter for console messages (status, errors)
-		consolePresenter := ui.NewPresenter(os.Stdout, os.Stderr)
-		ctx := cmd.Context()
-
-		// Determine the target for the main content output
-		var outputTarget io.WriteCloser = os.Stdout
-
-		if outputFile != "" {
-			file, err := os.Create(outputFile)
-			if err != nil {
-				consolePresenter.Error("Failed to create output file '%s': %v", outputFile, err)
-				return err
-			}
-			outputTarget = file
-			defer func() { _ = outputTarget.Close() }()
-		}
-
-		consolePresenter.Summary("Fetching GitHub issues for the current repository...")
-
-		if !ExecClient.CommandExists("gh") {
-			consolePresenter.Error("GitHub CLI ('gh') not found. This command is required.")
-			consolePresenter.Advice(
-				"Please install it from https://cli.github.com/ and authenticate with 'gh auth login'.",
-			)
-			return errors.New("gh cli not found")
-		}
-
-		consolePresenter.Step("Running 'gh issue list'...")
-		jsonFields := "number,title,author,body,comments"
-		stdout, stderr, err := ExecClient.CaptureOutput(
-			ctx,
-			".",
-			"gh",
-			"issue",
-			"list",
-			"--json",
-			jsonFields,
-		)
-		if err != nil {
-			consolePresenter.Error("Failed to fetch issues from GitHub CLI.")
-			consolePresenter.Detail("Error: %v", err)
-			if stderr != "" {
-				consolePresenter.Detail("Stderr: %s", stderr)
-			}
-			consolePresenter.Advice(
-				"Ensure you are in a GitHub repository and have run 'gh auth login'.",
-			)
-			return errors.New("gh issue list command failed")
-		}
-
-		var issues []Issue
-		if err := json.Unmarshal([]byte(stdout), &issues); err != nil {
-			consolePresenter.Error("Failed to parse JSON output from GitHub CLI: %v", err)
-			return err
-		}
-
-		if len(issues) == 0 {
-			consolePresenter.Info("No open issues found for this repository.")
-			return nil
-		}
-
-		// Write the formatted issues to the designated target (console or file)
-		for _, issue := range issues {
-			_, _ = issue.WriteTo(outputTarget)
-		}
-
-		if outputFile != "" {
-			consolePresenter.Success(
-				"Successfully wrote %d issue(s) to %s",
-				len(issues),
-				outputFile,
-			)
-		}
-
-		return nil
-	},
+	Short: "Manage your current task (the 'what'). Start, save, and finish work here.",
+	Long:  `The project domain represents the management of a specific unit of work. It is the "what"—the task at hand, the feature being built, the bug being fixed.`,
 }
 
 func init() {
-	listIssuesCmd.Flags().
-		StringVarP(&outputFile, "output", "o", "", "Path to save the output file.")
 	rootCmd.AddCommand(projectCmd)
-	projectCmd.AddCommand(listIssuesCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,8 @@ var (
 	LoadedAppConfig *config.Config
 	ExecClient      *exec.ExecutorClient
 	assumeYes       bool
-	AppVersion      string
+	// AppVersion is the application version, set at build time.
+	AppVersion string
 )
 
 var rootCmd = &cobra.Command{
@@ -81,7 +82,7 @@ var (
 
 func init() {
 	if AppVersion == "" {
-		AppVersion = "v0.2.0-dev" // Updated version
+		AppVersion = "dev" // Default for local development
 	}
 
 	rootCmd.PersistentFlags().

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,28 +1,37 @@
 package cmd
 
 import (
+	_ "embed"
+
+
+	"github.com/contextvibes/cli/internal/cmddocs"
 	"github.com/contextvibes/cli/internal/ui"
 	"github.com/spf13/cobra"
 )
 
+//go:embed version.md.tpl
+var versionLongDescription string
+
 // versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Show the version of the Context Vibes CLI",
-	Long:  `Display the version number of the Context Vibes CLI.`,
+	// Short and Long descriptions are now set dynamically in the init() function.
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Use cmd.OutOrStdout() so that output can be captured in tests
 		p := ui.NewPresenter(cmd.OutOrStdout(), cmd.ErrOrStderr())
 		p.Summary("Context Vibes CLI Version: " + AppVersion)
-
 		return nil
 	},
 }
 
-// init is called after all the variable declarations in the package have evaluated
-// their initializers, and after all imported packages have been initialized.
-// It is used here to add the versionCmd to the rootCmd.
-// The AppVersion variable is expected to be initialized in root.go's init().
 func init() {
+	// Dynamically set the descriptions by parsing and executing the template.
+	desc, err := cmddocs.ParseAndExecute(versionLongDescription, struct{ AppVersion string }{AppVersion: AppVersion})
+	if err != nil {
+		// This is a developer error, so we panic.
+		panic(err)
+	}
+	versionCmd.Short = desc.Short
+	versionCmd.Long = desc.Long
+
 	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/version.md.tpl
+++ b/cmd/version.md.tpl
@@ -1,0 +1,6 @@
+# Show the version of the Context Vibes CLI
+
+Displays the current version of the Context Vibes CLI.
+
+The version is determined at build time from the latest Git tag.
+This binary's version is: **{{.AppVersion}}**

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/contextvibes/cli
 go 1.24.2
 
 require (
+	github.com/charmbracelet/huh v0.7.0
 	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
 	github.com/fatih/color v1.18.0
 	github.com/spf13/cobra v1.9.1
@@ -38,7 +39,6 @@ require (
 )
 
 require (
-	github.com/charmbracelet/huh v0.7.0
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/cmddocs/parser.go
+++ b/internal/cmddocs/parser.go
@@ -1,0 +1,54 @@
+package cmddocs
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+)
+
+// CommandDesc contains the short and long descriptions for a cobra command.
+type CommandDesc struct {
+	Short string
+	Long  string
+}
+
+// ParseAndExecute parses a Markdown template, executes it with the provided data,
+// and extracts the Short and Long descriptions.
+// It expects the first non-empty line after templating to be an H1 title (e.g., "# Command Short Desc").
+func ParseAndExecute(templateContent string, data any) (CommandDesc, error) {
+	tmpl, err := template.New("cmddoc").Parse(templateContent)
+	if err != nil {
+		return CommandDesc{}, err
+	}
+
+	var executedTpl bytes.Buffer
+	if err := tmpl.Execute(&executedTpl, data); err != nil {
+		return CommandDesc{}, err
+	}
+
+	var shortDesc, longDesc string
+	lines := strings.Split(executedTpl.String(), "\n")
+	foundTitle := false
+	var longLines []string
+
+	for _, line := range lines {
+		if !foundTitle && strings.HasPrefix(line, "# ") {
+			shortDesc = strings.TrimSpace(strings.TrimPrefix(line, "# "))
+			foundTitle = true
+			continue
+		}
+		if foundTitle {
+			longLines = append(longLines, line)
+		}
+	}
+
+	if !foundTitle && len(lines) > 0 {
+		// Fallback if no H1 is found
+		shortDesc = lines[0]
+		longDesc = strings.Join(lines[1:], "\n")
+	} else {
+		longDesc = strings.TrimSpace(strings.Join(longLines, "\n"))
+	}
+
+	return CommandDesc{Short: shortDesc, Long: longDesc}, nil
+}

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,17 @@
+The project domain represents the management of a specific unit of work. It is the "what"—the task at hand, the feature being built, the bug being fixed.
+
+Usage:
+  contextvibes project [command]
+
+Available Commands:
+  improve     Create a new feature, bug, or chore suggestion as a GitHub Issue.
+
+Flags:
+  -h, --help   help for project
+
+Global Flags:
+      --ai-log-file string    AI (JSON) log file path
+      --log-level-ai string   AI (JSON) file log level (default "debug")
+  -y, --yes                   Assume 'yes' to all prompts
+
+Use "contextvibes project [command] --help" for more information about a command.


### PR DESCRIPTION
This commit introduces a suite of features to manage the project backlog directly from the CLI, establishing the new 'Craftsman's Workshop' architectural patterns.

- Adds a new  command with an interactive form for creating GitHub issues. This command also supports non-interactive use via flags.
- Establishes a new pattern for dynamic, templated command documentation () and implements it for the version is not installed, but available in the following packages, pick one to run it, Ctrl+C to cancel. command as a 'poster boy' example.
- Creates the parent  command group, laying the foundation for the new CLI architecture.
